### PR TITLE
Fix to an undef error

### DIFF
--- a/lib/Gearman/Taskset.pm
+++ b/lib/Gearman/Taskset.pm
@@ -85,7 +85,7 @@ sub cancel {
     }
 
     while (my ($hp, $sock) = each %{ $ts->{loaned_sock} }) {
-        $sock->close;
+        $sock->close if $sock;
     }
 
     $ts->{waiting}     = {};
@@ -102,7 +102,10 @@ sub _get_loaned_sock {
     }
 
     my $sock = $ts->{client}->_get_js_sock($hostport);
-    return $ts->{loaned_sock}{$hostport} = $sock;
+    if ($sock) {
+        $ts->{loaned_sock}{$hostport} = $sock;
+    }
+    return $sock;
 }
 
 # event loop for reading in replies


### PR DESCRIPTION
If the _get_js_sock function returns undef, it is placed into the
loaned_sock property inside _get_loaned_sock.  This can cause
'Can't call method "close" on an undefined value' later on; so, don't
put undef in there, and don't die when the value is undef.

Full(er) exception from real use:

Internal error in request handler : Can't call method "close" on an undefined value at REDACTED line XXX
    REDACTED('Can\'t call method "close" on an undefined value at /usr/lib/...') called at /usr/lib/perl5/site_perl/5.X.Y/Gearman/Taskset.pm line 87
    Gearman::Taskset::cancel('Gearman::Taskset=ARRAY(0x2190b3d0)') called at /usr/lib/perl5/site_perl/5.X.Y/Gearman/Taskset.pm line 142
    Gearman::Taskset::wait('Gearman::Taskset=ARRAY(0x2190b3d0)', 'timeout', 0.2) called at REDACTED line XXX
