### PR TITLE
Update MakeMaker's NAME argument to the "main module" Gearman::Client

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,8 @@ use ExtUtils::MakeMaker;
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
 WriteMakefile(
-              'NAME'=> 'Gearman',
+              'NAME'=> 'Gearman::Client',
+              'DISTNAME' => 'Gearman',
               'VERSION_FROM' => 'lib/Gearman/Client.pm',
               'PREREQ_PM' => {
                 String::CRC32 => 0,


### PR DESCRIPTION
MakeMaker's NAME argument has to be set to the "main module" of the distribution and in this distribution it is considered Gearman::Client.

For comparison, Template-Toolkit has NAME set to 'Template' and libwww-perl has NAME set to LWP.
