### PR TITLE
Add support for DATA packets

### DIFF
--- a/lib/Gearman/Objects.pm
+++ b/lib/Gearman/Objects.pm
@@ -48,6 +48,7 @@ use fields (
             'on_exception',
             'on_retry',
             'on_status',
+            'on_data',
             'on_post_hooks',   # used internally, when other hooks are done running, prior to cleanup
             'retry_count',
             'timeout',

--- a/lib/Gearman/Task.pm
+++ b/lib/Gearman/Task.pm
@@ -206,9 +206,17 @@ sub complete {
 sub status {
     my Gearman::Task $task = shift;
     return if $task->{is_finished};
-    return unless $task->{on_status};
+    
     my ($nu, $de) = @_;
     $task->{on_status}->($nu, $de);
+}
+
+sub data {
+    my Gearman::Task $task = shift;
+    return if $task->{is_finished};
+    my $result_ref = shift;
+    
+    $task->{on_data}->($result_ref)     if $task->{on_data};
 }
 
 # getter/setter for the fully-qualified handle of form "IP:port//shandle" where

--- a/lib/Gearman/Util.pm
+++ b/lib/Gearman/Util.pm
@@ -51,6 +51,7 @@ our %cmd = (
             # to one jobserver, so no polls/grabs will take place, and server is free
             # to push "job_assign" packets back down.
             24 => [ 'I', "all_yours" ],    # W->J ---
+            28 => [ 'IO', "work_data"],    # W->J/C: HANDLE[0]RES
             );
 
 our %num;  # name -> num


### PR DESCRIPTION
This patch should allow very rudementary support for WORK_DATA packets.  At the very least it won't cause Gearman::Client to die with "Unknown/unimplemented packet type" when one is encountered.
